### PR TITLE
Bump deno version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Deno
         uses: denoland/setup-deno@main
         with:
-          deno-version: 1.22.0
+          deno-version: 1.22.1
 
       - name: Build site
         run: deno run -A https://deno.land/x/lume/ci.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Deno
         uses: denoland/setup-deno@main
         with:
-          deno-version: 1.18.2
+          deno-version: 1.22.0
 
       - name: Build site
         run: deno run -A https://deno.land/x/lume/ci.ts


### PR DESCRIPTION
This PR ensures that the CI runs with a deno version `>= 1.20.1`, which is required by lume

cf. this failing build https://github.com/denoland/deploy_lume_example/runs/5664347044#step:4:45